### PR TITLE
parse: add @uv and @uw support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,10 @@ function yore(x: BigInteger): Dat {
     time,
   };
 }
-export function formatDa(x: BigInteger) {
+export function formatDa(x: BigInteger | string) {
+  if (typeof x === 'string') {
+    x = bigInt(x);
+  }
   const { year, month, time } = yore(x);
 
   return `~${year}.${month}.${time.day}..${time.hour}.${time.minute}.${
@@ -232,7 +235,10 @@ export function parseUv(x: string) {
   return res;
 }
 
-export function formatUv(x: BigInteger) {
+export function formatUv(x: BigInteger | string) {
+  if (typeof x === 'string') {
+    x = bigInt(x);
+  }
   let res = '';
   while (x.neq(bigInt.zero)) {
     let nextSix = x.and(uvMask).toJSNumber();
@@ -258,7 +264,10 @@ export function parseUw(x: string) {
   return res;
 }
 
-export function formatUw(x: BigInteger) {
+export function formatUw(x: BigInteger | string) {
+  if (typeof x === 'string') {
+    x = bigInt(x);
+  }
   let res = '';
   while (x.neq(bigInt.zero)) {
     let nextSix = x.and(uwMask).toJSNumber();

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,19 @@ function chunkFromRight(str: string, size: number) {
 const uvMask = bigInt(31);
 const uvAlphabet =
   '0123456789abcdefghijklmnopqrstuv';
+
+export function parseUv(x: string) {
+  let res = bigInt(0);
+  x = x.slice(2);
+  while (x !== '') {
+    if (x[0] !== '.') {
+      res = res.shiftLeft(5).add(uvAlphabet.indexOf(x[0]));
+    }
+    x = x.slice(1);
+  }
+  return res;
+}
+
 export function formatUv(x: BigInteger) {
   let res = '';
   while (x.neq(bigInt.zero)) {
@@ -232,6 +245,19 @@ export function formatUv(x: BigInteger) {
 const uwMask = bigInt(63);
 const uwAlphabet =
   '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-~';
+
+export function parseUw(x: string) {
+  let res = bigInt(0);
+  x = x.slice(2);
+  while (x !== '') {
+    if (x[0] !== '.') {
+      res = res.shiftLeft(6).add(uwAlphabet.indexOf(x[0]));
+    }
+    x = x.slice(1);
+  }
+  return res;
+}
+
 export function formatUw(x: BigInteger) {
   let res = '';
   while (x.neq(bigInt.zero)) {

--- a/test/blah.test.ts
+++ b/test/blah.test.ts
@@ -1,4 +1,4 @@
-import { formatDa, formatUv, formatUw, parseDa } from '../src';
+import { formatDa, parseDa, formatUw, parseUw, formatUv, parseUv } from '../src';
 import bigInt, { BigInteger } from 'big-integer';
 
 const DA_PAIRS: [string, BigInteger][] = [
@@ -26,38 +26,63 @@ describe('@da', () => {
     });
   });
 });
+
+const UW_PAIRS: [string, BigInteger][] = [
+  [
+    '0wji',
+    bigInt(1234),
+  ],
+  [
+    '0w2.VNFPq.zLWXr.mHG98.cOSaU.jD-HK.WOAEW.icKX-.-UOti.RrLxM.BEdKI.U8j~T.rgqLe.HuVVm.m5aDi.FcUj0.z-9H9.PWYVS',
+    bigInt('9729869760580312915057700420931106632029212932045019789366559593013069886734510969807231346927570172527456683282759587841913712910138850310449267827527286'),
+  ],
+  [
+    '0w8.~wwXK.5Jbvq.EPFfs.mWqAa.G6VLL.Hp5RZ.1ztU0.OdjK6.rwC4f.IUflm.bew2G.q2V58.Yvb-y.8D7JP.mAX5-.tTUnZ.4PIzy.fU8eX.xriTS.GcWjT.5KCF2.GxKrX.WShtv.goTu0.czkXx.CU9x3.Xe3Rl.yPE0G.CwKhi.f7O~E.y9NXs.RFeNv.Dt-5~.hcX8U.z-23K.UmQJZ.GzeAZ.NrFGg.GErC-.-JAnn.Q6dTw.38ReU.pK2og.-PwZl.oIW0a.FEbAk.zNYLW.8ysuT.dqjIn.VTvxv.QjeOe',
+    bigInt('338660688809191135992117047766620650717811482934943979674885003948246397791915632356127816874957444994283298782534439422236465196123969501940528462017413072176474702992911473379692926314882846435461316330442229390384286920909868601208813714735355172837223931275587957994082972971545840145432819726749971121524031459169847685770572005049993814978529576884322644499161452167351136603982630270130940863597682766057587354154988711969349941809951888309135835193470094'),
+  ]
+];
 describe('@uw', () => {
-  it('formats', () => {
-    let num = bigInt(1234);
-    let res = '0wji';
-    expect(formatUw(num)).toBe(res);
-  });
-  it('formats two', () => {
-    let num = bigInt(
-      '9.729.869.760.580.312.915.057.700.420.931.106.632.029.212.932.045.019.789.366.559.593.013.069.886.734.510.969.807.231.346.927.570.172.527.456.683.282.759.587.841.913.712.910.138.850.310.449.267.827.527.286'
-        .split('.')
-        .join('')
-    );
-    let res =
-      '0w2.VNFPq.zLWXr.mHG98.cOSaU.jD-HK.WOAEW.icKX-.-UOti.RrLxM.BEdKI.U8j~T.rgqLe.HuVVm.m5aDi.FcUj0.z-9H9.PWYVS';
-    expect(formatUw(num)).toBe(res);
+  UW_PAIRS.map(([uw, integer], idx) => {
+    describe(`case ${idx}`, () => {
+      it('parses', () => {
+        const res = parseUw(uw);
+        const diff = integer.minus(res);
+        expect(diff.eq(bigInt.zero)).toBe(true);
+      });
+      it('formats', () => {
+        const res = formatUw(integer);
+        expect(res).toEqual(uw);
+      });
+    });
   });
 });
 
+const UV_PAIRS: [string, BigInteger][] = [
+  [
+    '0v16i',
+    bigInt(1234),
+  ],
+  [
+    '0v1d0.l2h7n.mo1ro.s3r8e.4f6gd.dfsp1.hc5en.a0k8j.1v7vk.16jqd.oog39.5ool7.mrkdp.vvofi.gd2d6.vnmi9.a1dlt.7lbbm.iq76k.u5ivc.pp8qa',
+    bigInt('4715838753694475992579249794985609354876653107513376869107585916141874120351297535898666953377988719385257642282348313095587079274499396365843215360500554'),
+  ],
+  [
+    '0v1q7.2j1o2.gsrac.v0lr2.4qq3l.dl4dl.geimi.ti4kn.nerpk.io8e9.fb6u8.qdo3a.f6jnl.4t0ro.mnphj.45eu3.aasog.tgnop.mgknj.vrf7c.qh8uk.uhoko.e0k76.qj7o5.eoh6m.gtbd9.3dc3k.lknch.55trm.ud4m2.3ibqp.ni6je.0qjpk.tt978.6u5lu.ccp1b.ngqin.647c5.u6dk5.5svur.pr6ka.7l7ke.563g5.1pmkp.u1bm4.9lk7a.ra8rb.0t5d5.r499f.etnj9.5ggsi.umdsh.krg6k.ud7fa.9q1nh.dfj36.8ats6.klph1.r1fhj.d19f7.vmuep.l2ht9',
+    bigInt('2192679466494434890472543084060582766548642415978526232232529756549132081077716901494847003622252677433111645469887112954835308752404322485369993198040597565692723588585723772692969275396046341198068016409658069930178326315327541379152850899800598824712189194725563892210423915200062671509436137248472305920263160462934628062386175666117414052493363024883656571948762124184585291750029792031534226654202512820124560651712985859227347538529179923696933418921183145'),
+  ]
+];
 describe('@uv', () => {
-  it('formats', () => {
-    let num = bigInt(1234);
-    let res = '0v16i';
-    expect(formatUv(num)).toBe(res);
-  });
-  it('formats two', () => {
-    let num = bigInt(
-      '4.715.838.753.694.475.992.579.249.794.985.609.354.876.653.107.513.376.869.107.585.916.141.874.120.351.297.535.898.666.953.377.988.719.385.257.642.282.348.313.095.587.079.274.499.396.365.843.215.360.500.554'
-        .split('.')
-        .join('')
-    );
-    let res =
-      '0v1d0.l2h7n.mo1ro.s3r8e.4f6gd.dfsp1.hc5en.a0k8j.1v7vk.16jqd.oog39.5ool7.mrkdp.vvofi.gd2d6.vnmi9.a1dlt.7lbbm.iq76k.u5ivc.pp8qa'
-    expect(formatUv(num)).toBe(res);
+  UV_PAIRS.map(([uv, integer], idx) => {
+    describe(`case ${idx}`, () => {
+      it('parses', () => {
+        const res = parseUv(uv);
+        const diff = integer.minus(res);
+        expect(diff.eq(bigInt.zero)).toBe(true);
+      });
+      it('formats', () => {
+        const res = formatUv(integer);
+        expect(res).toEqual(uv);
+      });
+    });
   });
 });


### PR DESCRIPTION
Also refactors their tests to match @da, and adds even larger test cases.

The dumb approach here of simply doing `alphabet.indexOf` seems plenty fast. Checking and adjusting the value of `x.charAt(0)` wasn't noticeably faster, and using a separate alphabet lookup table is actually a bit slower.

CI is giving red Xs on master also, so I'm ignoring it. (;