### PR TITLE
bigint: use native bigint instead of big-integer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 jobs:
   build:
-    name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}
+    name: Build and test on Node ${{ matrix.node }} and ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -21,9 +21,6 @@ jobs:
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1
-
-      - name: Lint
-        run: yarn lint
 
       - name: Test
         run: yarn test --ci --coverage --maxWorkers=2

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ This NPM package is intended to ease the flow of developing FE applications for 
 
 ```typescript
 // @da manipulation
-function parseDa(da: string): BigInteger;
-function formatDa(da: BigInteger): string;
+function parseDa(da: string): bigint;
+function formatDa(da: bigint): string;
 // Given a bigint representing an urbit date, returns a unix timestamp.
-function daToUnix(da: BigInteger): number;
+function daToUnix(da: bigint): number;
 // Given a unix timestamp, returns a bigint representing an urbit date
-function unixToDa(unix: number): BigInteger;
+function unixToDa(unix: number): bigint;
 
 // @p manipulation
 // Convert a number to a @p-encoded string.
-function patp(arg: string | number | BigInteger): string;
+function patp(arg: string | number | bigint): string;
 function hex2patp(hex: string): string;
 function patp2hex(name: string): string;
-function patp2bn(name: string): BigInteger;
+function patp2bn(name: string): bigint;
 function patp2dec(name: string): string;
 // Determine the ship class of a @p value.
 function clan(who: string): string;
@@ -35,10 +35,10 @@ function cite(ship: string): string | null;
 
 // @q manipulation
 // Convert a number to a @q-encoded string.
-function patq(arg: string | number | BigInteger): string;
+function patq(arg: string | number | bigint): string;
 function hex2patq(arg: string): string;
 function patq2hex(name: string): string;
-function patq2bn(name: string): BigInteger;
+function patq2bn(name: string): bigint;
 function patq2dec(name: string): string;
 // Validate a @q string.
 function isValidPatq(str: string): boolean;
@@ -46,16 +46,16 @@ function isValidPatq(str: string): boolean;
 function eqPatq(p: string, q: string): boolean;
 
 // @ud manipulation
-function parseUd(ud: string): BigInteger;
-function formatUd(ud: BigInteger): string;
+function parseUd(ud: string): bigint;
+function formatUd(ud: bigint): string;
 
 // @uv manipulation
-function parseUv(x: string): BigInteger;
-function formatUv(x: BigInteger | string): string;
+function parseUv(x: string): bigint;
+function formatUv(x: bigint | string): string;
 
 // @uw manipulation
-function parseUw(x: string): BigInteger;
-function formatUw(x: BigInteger | string): string;
+function parseUw(x: string): bigint;
+function formatUw(x: bigint | string): string;
 
 // @ux manipulation
 function parseUx(ux: string): string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,6 @@
       "engines": {
         "node": ">=16",
         "npm": ">=8"
-      },
-      "peerDependencies": {
-        "big-integer": "^1.6.51"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3995,15 +3992,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.6"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -13664,12 +13652,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
-    },
-    "big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "peer": true
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "size": "size-limit",
     "analyze": "size-limit --why"
   },
-  "peerDependencies": {
-    "big-integer": "^1.6.51"
-  },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^8.2.4",
     "@tsconfig/recommended": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "name": "@urbit/aura",
-  "author": "Liam Fitzgerald",
   "module": "dist/aura.esm.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "start": "dts watch",
     "build": "dts build",
     "test": "dts test",
-    "lint": "dts lint",
     "prepare": "dts build",
     "size": "size-limit",
     "analyze": "size-limit --why"
@@ -42,13 +41,6 @@
     "hooks": {
       "pre-commit": "dts lint"
     }
-  },
-  "prettier": {
-    "printWidth": 80,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "endOfLine": "auto"
   },
   "size-limit": [
     {

--- a/src/hoon/index.ts
+++ b/src/hoon/index.ts
@@ -1,8 +1,3 @@
-import bigInt, { BigInteger } from 'big-integer';
-
-const zero = bigInt(0);
-const one = bigInt(1);
-const two = bigInt(2);
 
 export const pre = `
 dozmarbinwansamlitsighidfidlissogdirwacsabwissib\
@@ -45,16 +40,16 @@ lyrtesmudnytbyrsenwegfyrmurtelreptegpecnelnevfes\
 export const prefixes = pre.match(/.{1,3}/g) as RegExpMatchArray;
 export const suffixes = suf.match(/.{1,3}/g) as RegExpMatchArray;
 
-export const bex = (n: BigInteger) => two.pow(n);
+export const bex = (n: bigint) => 2n ** n;
 
-export const rsh = (a: BigInteger, b: BigInteger, c: BigInteger) =>
-  c.divide(bex(bex(a).multiply(b)));
+export const rsh = (a: bigint, b: bigint, c: bigint) =>
+  c / bex(bex(a) * b);
 
-export const met = (a: BigInteger, b: BigInteger, c = zero): BigInteger =>
-  b.eq(zero) ? c : met(a, rsh(a, one, b), c.add(one));
+export const met = (a: bigint, b: bigint, c = 0n): bigint =>
+  (b === 0n) ? c : met(a, rsh(a, 1n, b), c + 1n);
 
-export const end = (a: BigInteger, b: BigInteger, c: BigInteger) =>
-  c.mod(bex(bex(a).multiply(b)));
+export const end = (a: bigint, b: bigint, c: bigint) =>
+  c % bex(bex(a) * b);
 
 export const patp2syls = (name: string): string[] =>
   name.replace(/[\^~-]/g, '').match(/.{1,3}/g) || [];

--- a/src/hoon/muk.ts
+++ b/src/hoon/muk.ts
@@ -1,25 +1,20 @@
-import bigInt, { BigInteger } from 'big-integer';
 // ++  muk
 //
 // See arvo/sys/hoon.hoon.
-
-const ux_FF = bigInt(0xff);
-const ux_FF00 = bigInt(0xff00);
-const u_256 = bigInt(256);
 
 /**
  * Standard murmur3.
  *
  * @param  {Number}       syd
  * @param  {Number}       len
- * @param  {BigInteger}   key
- * @return {BigInteger}
+ * @param  {bigint}       key
+ * @return {bigint}
  */
-export const muk = (syd: number, key: BigInteger) => {
-  const lo = key.and(ux_FF).toJSNumber();
-  const hi = key.and(ux_FF00).divide(u_256).toJSNumber();
+export const muk = (syd: number, key: bigint): bigint => {
+  const lo = Number(key & 0xffn);
+  const hi = Number((key & 0xff00n) / 256n);
   const kee = String.fromCharCode(lo) + String.fromCharCode(hi);
-  return bigInt(murmurhash3_32_gc(kee, syd));
+  return BigInt(murmurhash3_32_gc(kee, syd));
 };
 
 // see: https://github.com/garycourt/murmurhash-js

--- a/src/p.ts
+++ b/src/p.ts
@@ -1,4 +1,3 @@
-import bigInt, { BigInteger } from 'big-integer';
 import {
   isValidPat,
   patp2syls,
@@ -10,13 +9,6 @@ import {
 } from './hoon';
 import ob from './hoon/ob';
 
-const zero = bigInt(0);
-const one = bigInt(1);
-const two = bigInt(2);
-const three = bigInt(3);
-const four = bigInt(4);
-const five = bigInt(5);
-
 /**
  * Convert a hex-encoded string to a @p-encoded string.
  *
@@ -27,7 +19,7 @@ export function hex2patp(hex: string): string {
   if (hex === null) {
     throw new Error('hex2patp: null input');
   }
-  return patp(bigInt(hex, 16));
+  return patp(BigInt('0x'+hex));
 }
 
 /**
@@ -52,7 +44,7 @@ export function patp2hex(name: string): string {
     ''
   );
 
-  const bn = bigInt(addr, 2);
+  const bn = BigInt('0b'+addr);
   const hex = ob.fynd(bn).toString(16);
   return hex.length % 2 !== 0 ? hex.padStart(hex.length + 1, '0') : hex;
 }
@@ -61,10 +53,10 @@ export function patp2hex(name: string): string {
  * Convert a @p-encoded string to a bignum.
  *
  * @param  {String}  name @p
- * @return  {BigInteger}
+ * @return  {bigint}
  */
-export function patp2bn(name: string): BigInteger {
-  return bigInt(patp2hex(name), 16);
+export function patp2bn(name: string): bigint {
+  return BigInt('0x'+patp2hex(name));
 }
 
 /**
@@ -74,7 +66,7 @@ export function patp2bn(name: string): BigInteger {
  * @return  {String}
  */
 export function patp2dec(name: string): string {
-  let bn: BigInteger;
+  let bn: bigint;
   try {
     bn = patp2bn(name);
   } catch (_) {
@@ -90,21 +82,21 @@ export function patp2dec(name: string): string {
  * @return  {String}
  */
 export function clan(who: string): string {
-  let name: BigInteger;
+  let name: bigint;
   try {
     name = patp2bn(who);
   } catch (_) {
     throw new Error('clan: not a valid @p');
   }
 
-  const wid = met(three, name);
-  return wid.leq(one)
+  const wid = met(3n, name);
+  return wid <= 1n
     ? 'galaxy'
-    : wid.eq(two)
+    : wid === 2n
     ? 'star'
-    : wid.leq(four)
+    : wid <= 4n
     ? 'planet'
-    : wid.leq(bigInt(8))
+    : wid <= 8n
     ? 'moon'
     : 'comet';
 }
@@ -116,7 +108,7 @@ export function clan(who: string): string {
  * @return  {String}
  */
 export function sein(name: string): string {
-  let who: BigInteger;
+  let who: bigint;
   try {
     who = patp2bn(name);
   } catch (_) {
@@ -134,12 +126,12 @@ export function sein(name: string): string {
     mir === 'galaxy'
       ? who
       : mir === 'star'
-      ? end(three, one, who)
+      ? end(3n, 1n, who)
       : mir === 'planet'
-      ? end(four, one, who)
+      ? end(4n, 1n, who)
       : mir === 'moon'
-      ? end(five, one, who)
-      : zero;
+      ? end(5n, 1n, who)
+      : 0n;
   return patp(res);
 }
 
@@ -156,33 +148,33 @@ export function isValidPatp(str: string): boolean {
 /**
  * Convert a number to a @p-encoded string.
  *
- * @param  {String, Number, BN}  arg
+ * @param  {String, Number, bigint}  arg
  * @return  {String}
  */
-export function patp(arg: string | number | BigInteger) {
+export function patp(arg: string | number | bigint) {
   if (arg === null) {
     throw new Error('patp: null input');
   }
-  const n = bigInt(arg as any);
+  const n = BigInt(arg);
 
   const sxz = ob.fein(n);
-  const dyy = met(four, sxz);
+  const dyy = met(4n, sxz);
 
-  function loop(tsxz: BigInteger, timp: BigInteger, trep: string): string {
-    const log = end(four, one, tsxz);
-    const pre = prefixes[rsh(three, one, log).toJSNumber()];
-    const suf = suffixes[end(three, one, log).toJSNumber()];
-    const etc = timp.mod(four).eq(zero) ? (timp.eq(zero) ? '' : '--') : '-';
+  function loop(tsxz: bigint, timp: bigint, trep: string): string {
+    const log = end(4n, 1n, tsxz);
+    const pre = prefixes[Number(rsh(3n, 1n, log))];
+    const suf = suffixes[Number(end(3n, 1n, log))];
+    const etc = (timp % 4n) === 0n ? ((timp === 0n) ? '' : '--') : '-';
 
     const res = pre + suf + etc + trep;
 
-    return timp.eq(dyy) ? trep : loop(rsh(four, one, tsxz), timp.add(one), res);
+    return timp === dyy ? trep : loop(BigInt(rsh(4n, 1n, tsxz).toString()), timp + 1n, res);
   }
 
-  const dyx = met(three, sxz);
+  const dyx = BigInt(met(3n, sxz).toString());
 
   return (
-    '~' + (dyx.leq(one) ? suffixes[sxz.toJSNumber()] : loop(sxz, zero, ''))
+    '~' + (dyx <= 1n ? suffixes[Number(sxz)] : loop(BigInt(sxz.toString()), 0n, ''))
   );
 }
 

--- a/src/ud.ts
+++ b/src/ud.ts
@@ -1,23 +1,22 @@
-import bigInt, { BigInteger } from 'big-integer';
 import { chunk } from './utils';
 
 /**
  * Given a string representing a @ud, returns a bigint
  *
  * @param   {string}      ud  the number as @ud
- * @return  {BigInteger}      the number as bigint
+ * @return  {bigint}          the number as bigint
  */
-export function parseUd(ud: string): BigInteger {
-  return bigInt(ud.replace(/\./g, ''));
+export function parseUd(ud: string): bigint {
+  return BigInt(ud.replace(/\./g, ''));
 }
 
 /**
  * Given a bigint representing a @ud, returns a proper @ud as string
  *
- * @param  {BigInteger} ud  the number as bigint
+ * @param  {bigint}     ud  the number as bigint
  * @return {string}         the number as @ud
  */
-export function formatUd(ud: BigInteger): string {
+export function formatUd(ud: bigint): string {
   const transform = chunk(ud.toString().split('').reverse(), 3)
     .map((group) => group.reverse().join(''))
     .reverse()

--- a/src/uv.ts
+++ b/src/uv.ts
@@ -3,7 +3,7 @@ import { chunkFromRight } from './utils';
 const uvAlphabet = '0123456789abcdefghijklmnopqrstuv';
 
 export function parseUv(x: string) {
-  let res = 0n;  //TODO  0n
+  let res = 0n;
   x = x.slice(2);
   while (x !== '') {
     if (x[0] !== '.') {

--- a/src/uv.ts
+++ b/src/uv.ts
@@ -1,30 +1,28 @@
-import bigInt, { BigInteger } from 'big-integer';
 import { chunkFromRight } from './utils';
 
-const uvMask = bigInt(31);
 const uvAlphabet = '0123456789abcdefghijklmnopqrstuv';
 
 export function parseUv(x: string) {
-  let res = bigInt(0);
+  let res = 0n;  //TODO  0n
   x = x.slice(2);
   while (x !== '') {
     if (x[0] !== '.') {
-      res = res.shiftLeft(5).add(uvAlphabet.indexOf(x[0]));
+      res = (res << 5n) + BigInt(uvAlphabet.indexOf(x[0]));
     }
     x = x.slice(1);
   }
   return res;
 }
 
-export function formatUv(x: BigInteger | string) {
+export function formatUv(x: bigint | string) {
   if (typeof x === 'string') {
-    x = bigInt(x);
+    x = BigInt(x);
   }
   let res = '';
-  while (x.neq(bigInt.zero)) {
-    let nextSix = x.and(uvMask).toJSNumber();
-    res = uvAlphabet[nextSix] + res;
-    x = x.shiftRight(5);
+  while (x !== 0n) {
+    let nextFive = Number(BigInt.asUintN(5, x));
+    res = uvAlphabet[nextFive] + res;
+    x = x >> 5n;
   }
   return `0v${chunkFromRight(res, 5).join('.')}`;
 }

--- a/src/uw.ts
+++ b/src/uw.ts
@@ -1,31 +1,29 @@
-import bigInt, { BigInteger } from 'big-integer';
 import { chunkFromRight } from './utils';
 
-const uwMask = bigInt(63);
 const uwAlphabet =
   '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-~';
 
 export function parseUw(x: string) {
-  let res = bigInt(0);
+  let res = 0n;
   x = x.slice(2);
   while (x !== '') {
     if (x[0] !== '.') {
-      res = res.shiftLeft(6).add(uwAlphabet.indexOf(x[0]));
+      res = (res << 6n) + BigInt(uwAlphabet.indexOf(x[0]));
     }
     x = x.slice(1);
   }
   return res;
 }
 
-export function formatUw(x: BigInteger | string) {
+export function formatUw(x: bigint | string) {
   if (typeof x === 'string') {
-    x = bigInt(x);
+    x = BigInt(x);
   }
   let res = '';
-  while (x.neq(bigInt.zero)) {
-    let nextSix = x.and(uwMask).toJSNumber();
+  while (x !== 0n) {
+    let nextSix = Number(BigInt.asUintN(6, x));
     res = uwAlphabet[nextSix] + res;
-    x = x.shiftRight(6);
+    x = x >> 6n;
   }
   return `0w${chunkFromRight(res, 5).join('.')}`;
 }

--- a/test/aura.test.ts
+++ b/test/aura.test.ts
@@ -10,16 +10,15 @@ import {
   parseUx,
   formatUx,
 } from '../src';
-import bigInt, { BigInteger } from 'big-integer';
 
-const DA_PAIRS: [string, BigInteger][] = [
+const DA_PAIRS: [string, bigint][] = [
   [
     '~2022.5.2..15.50.20..b4cb',
-    bigInt('170141184505617087925707667943685357568'),
+    BigInt('170141184505617087925707667943685357568'),
   ],
   [
     '~2022.5.2..18.52.34..8166.240c.0635.b423',
-    bigInt('170141184505617289618704043249403016227'),
+    BigInt('170141184505617289618704043249403016227'),
   ],
 ];
 describe('@da', () => {
@@ -27,8 +26,8 @@ describe('@da', () => {
     describe(`case ${idx}`, () => {
       it('parses', () => {
         const res = parseDa(da);
-        const diff = integer.minus(res);
-        expect(diff.eq(bigInt.zero)).toBe(true);
+        const diff = integer - res;
+        expect(diff == 0n).toBe(true);
       });
       it('formats', () => {
         const res = formatDa(integer);
@@ -38,12 +37,12 @@ describe('@da', () => {
   });
 });
 
-const UD_PAIRS: [string, BigInteger][] = [
-  ['123', bigInt(123)],
-  ['7.827.527.286', bigInt(7827527286)],
+const UD_PAIRS: [string, bigint][] = [
+  ['123', 123n],
+  ['7.827.527.286', 7827527286n],
   [
     '927.570.172.527.456.683.282.759.587.841.913.712.910.138.850.310.449.267.827.527.286',
-    bigInt('927570172527456683282759587841913712910138850310449267827527286'),
+    BigInt('927570172527456683282759587841913712910138850310449267827527286'),
   ],
 ];
 
@@ -52,8 +51,8 @@ describe('@ud', () => {
     describe(`case ${idx}`, () => {
       it('parses', () => {
         const res = parseUd(ud);
-        const diff = integer.minus(res);
-        expect(diff.eq(bigInt.zero)).toBe(true);
+        const diff = integer - res;
+        expect(diff === 0n).toBe(true);
       });
       it('formats', () => {
         const res = formatUd(integer);
@@ -63,17 +62,17 @@ describe('@ud', () => {
   });
 });
 
-const UW_PAIRS: [string, BigInteger][] = [
-  ['0wji', bigInt(1234)],
+const UW_PAIRS: [string, bigint][] = [
+  ['0wji', 1234n],
   [
     '0w2.VNFPq.zLWXr.mHG98.cOSaU.jD-HK.WOAEW.icKX-.-UOti.RrLxM.BEdKI.U8j~T.rgqLe.HuVVm.m5aDi.FcUj0.z-9H9.PWYVS',
-    bigInt(
+    BigInt(
       '9729869760580312915057700420931106632029212932045019789366559593013069886734510969807231346927570172527456683282759587841913712910138850310449267827527286'
     ),
   ],
   [
     '0w8.~wwXK.5Jbvq.EPFfs.mWqAa.G6VLL.Hp5RZ.1ztU0.OdjK6.rwC4f.IUflm.bew2G.q2V58.Yvb-y.8D7JP.mAX5-.tTUnZ.4PIzy.fU8eX.xriTS.GcWjT.5KCF2.GxKrX.WShtv.goTu0.czkXx.CU9x3.Xe3Rl.yPE0G.CwKhi.f7O~E.y9NXs.RFeNv.Dt-5~.hcX8U.z-23K.UmQJZ.GzeAZ.NrFGg.GErC-.-JAnn.Q6dTw.38ReU.pK2og.-PwZl.oIW0a.FEbAk.zNYLW.8ysuT.dqjIn.VTvxv.QjeOe',
-    bigInt(
+    BigInt(
       '338660688809191135992117047766620650717811482934943979674885003948246397791915632356127816874957444994283298782534439422236465196123969501940528462017413072176474702992911473379692926314882846435461316330442229390384286920909868601208813714735355172837223931275587957994082972971545840145432819726749971121524031459169847685770572005049993814978529576884322644499161452167351136603982630270130940863597682766057587354154988711969349941809951888309135835193470094'
     ),
   ],
@@ -83,8 +82,8 @@ describe('@uw', () => {
     describe(`case ${idx}`, () => {
       it('parses', () => {
         const res = parseUw(uw);
-        const diff = integer.minus(res);
-        expect(diff.eq(bigInt.zero)).toBe(true);
+        const diff = integer - res;
+        expect(diff === 0n).toBe(true);
       });
       it('formats', () => {
         const res = formatUw(integer);
@@ -94,17 +93,17 @@ describe('@uw', () => {
   });
 });
 
-const UV_PAIRS: [string, BigInteger][] = [
-  ['0v16i', bigInt(1234)],
+const UV_PAIRS: [string, bigint][] = [
+  ['0v16i', 1234n],  //TODO  1234n
   [
     '0v1d0.l2h7n.mo1ro.s3r8e.4f6gd.dfsp1.hc5en.a0k8j.1v7vk.16jqd.oog39.5ool7.mrkdp.vvofi.gd2d6.vnmi9.a1dlt.7lbbm.iq76k.u5ivc.pp8qa',
-    bigInt(
+    BigInt(
       '4715838753694475992579249794985609354876653107513376869107585916141874120351297535898666953377988719385257642282348313095587079274499396365843215360500554'
     ),
   ],
   [
     '0v1q7.2j1o2.gsrac.v0lr2.4qq3l.dl4dl.geimi.ti4kn.nerpk.io8e9.fb6u8.qdo3a.f6jnl.4t0ro.mnphj.45eu3.aasog.tgnop.mgknj.vrf7c.qh8uk.uhoko.e0k76.qj7o5.eoh6m.gtbd9.3dc3k.lknch.55trm.ud4m2.3ibqp.ni6je.0qjpk.tt978.6u5lu.ccp1b.ngqin.647c5.u6dk5.5svur.pr6ka.7l7ke.563g5.1pmkp.u1bm4.9lk7a.ra8rb.0t5d5.r499f.etnj9.5ggsi.umdsh.krg6k.ud7fa.9q1nh.dfj36.8ats6.klph1.r1fhj.d19f7.vmuep.l2ht9',
-    bigInt(
+    BigInt(
       '2192679466494434890472543084060582766548642415978526232232529756549132081077716901494847003622252677433111645469887112954835308752404322485369993198040597565692723588585723772692969275396046341198068016409658069930178326315327541379152850899800598824712189194725563892210423915200062671509436137248472305920263160462934628062386175666117414052493363024883656571948762124184585291750029792031534226654202512820124560651712985859227347538529179923696933418921183145'
     ),
   ],
@@ -114,8 +113,8 @@ describe('@uv', () => {
     describe(`case ${idx}`, () => {
       it('parses', () => {
         const res = parseUv(uv);
-        const diff = integer.minus(res);
-        expect(diff.eq(bigInt.zero)).toBe(true);
+        const diff = integer - res;
+        expect(diff === 0n).toBe(true);
       });
       it('formats', () => {
         const res = formatUv(integer);

--- a/test/aura.test.ts
+++ b/test/aura.test.ts
@@ -94,7 +94,7 @@ describe('@uw', () => {
 });
 
 const UV_PAIRS: [string, bigint][] = [
-  ['0v16i', 1234n],  //TODO  1234n
+  ['0v16i', 1234n],
   [
     '0v1d0.l2h7n.mo1ro.s3r8e.4f6gd.dfsp1.hc5en.a0k8j.1v7vk.16jqd.oog39.5ool7.mrkdp.vvofi.gd2d6.vnmi9.a1dlt.7lbbm.iq76k.u5ivc.pp8qa',
     BigInt(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
-    "moduleResolution": "nodenext"
+    "moduleResolution": "nodenext",
+    "target": "es2020"
   }
 }


### PR DESCRIPTION
To make it easier for our libraries to be used together, we are doing a pass over them, standardizing on using native bigint for big numbers. Nock-js already uses these. This library should follow.

This commit updates all aura-js library code to use native bigints, and removed the big-integer dependency altogether.

Not included is a version number bump. Since this changes the kinds of numbers we expose/ingest, this is a breaking API change.